### PR TITLE
fix calendar view on mobile

### DIFF
--- a/src/components/Calendar/Calendar.scss
+++ b/src/components/Calendar/Calendar.scss
@@ -1,10 +1,19 @@
-@import '~@fullcalendar/core/main.css';
-@import '~@fullcalendar/daygrid/main.css';
+@import "~@fullcalendar/core/main.css";
+@import "~@fullcalendar/daygrid/main.css";
 
 .calendar-container {
-    border-top: 4px solid #fac863;
-    padding-top: 20px;
-    margin-top: 20px;
+  border-top: 4px solid #fac863;
+  padding-top: 20px;
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+  .fc-right {
     display: flex;
-    align-items: center;
+  }
+  @media only screen and (max-width: 576px) {
+    .fc-center {
+      font-size: 12px;
+      text-align: center;
+    }
+  }
 }


### PR DESCRIPTION
*Enable the calendar title to take the entire width of the screen when in mobile view
*Decrease the font size for the calendar month in mobile view